### PR TITLE
removed required for event_id and event_name in get_discord_event

### DIFF
--- a/src/api/v1/events/discord_event.py
+++ b/src/api/v1/events/discord_event.py
@@ -19,8 +19,8 @@ router = APIRouter()
 
 @router.get("/")
 async def get_discord_event(
-    event_id: Annotated[int | None, Query()],
-    event_name: Annotated[str | None, Query()],
+    event_id: int = Query(None, alias="event_id"),
+    event_name: str = Query(None, alias="event_name"),
     usr: bool = Depends(authenticate_user),
     repo: DiscordEventRepository = Depends(get_discord_event_repository),
 ):


### PR DESCRIPTION
The Get call for the Discord Event required both an event_id and event_name. Removed the requirement, so this now matches the SQL call.
Can now get with either event_id or event_name